### PR TITLE
use title from /services/_index.md or "Our Services" as fallback

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -41,7 +41,7 @@
 <div class="container pt-8 pb-8 pb-md-14 pt-md-14">
   <div class="row justify-content-start">
     <div class="col-12">
-      <h2 class="text-center mb-3">Our Services</h2>
+      <h2 class="text-center mb-3">{{ with .Site.GetPage "/services/" }}{{ .Title | default "Our Services" }}{{ end }}</h2>
     </div>
     {{ range first 6 (sort $services ".Params.weight") }}
     <div class="col-12 col-md-4 mb-1">


### PR DESCRIPTION
As discussed in #63, this uses the title from `/services/` if it exists, or falls back to "Our Services".