### PR TITLE
fix: update unreachable live demo link to correct URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Hero is a multi-page business theme with fullscreen hero images and fullwidth sections.
 
-[Live Demo](https://hugo-hero.netlify.com/) |
+[Live Demo](https://hugo-hero.netlify.app/) |
 [Zerostatic Themes](https://www.zerostatic.io/theme/hugo-hero/)
 
 ![Hugo Hero Theme screenshot](https://www.zerostatic.io/theme/hugo-hero/hugo-hero-screenshot.png)


### PR DESCRIPTION
Like mentioned in the PR title, the current link to the live demo site (ending in `.com`) is unreachable.
This PR switching to the `.app` TLD, which is reachable.

Cool theme :)

Just a heads up, the "About" section of the repo here would need to be updated as well.