### PR TITLE
Replace `.Site.IsServer` with `hugo.IsServer`

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,7 +9,7 @@
   {{ block "meta_tags" . }}{{end}}
   <link rel="icon" href="{{ .Site.BaseURL }}favicon.png">
 
-  {{ if .Site.IsServer }}
+  {{ if hugo.IsServer }}
   {{ $style := resources.Get "scss/style.scss" | toCSS (dict "targetPath" "css/style.css" "enableSourceMap" true) }}
   <link rel="stylesheet" href="{{ ($style).RelPermalink }}">
   {{ else }}
@@ -37,7 +37,7 @@
   {{ block "footer_js" . }}
   {{ end }}
 
-  {{ if .Site.IsServer }}
+  {{ if hugo.IsServer }}
   <script type="text/javascript" src="{{ $scripts.RelPermalink }}"></script>
   {{ else }}
   <script type="text/javascript" src="{{ ($scripts | minify | fingerprint).RelPermalink }}"></script>

--- a/layouts/partials/google-analytics.html
+++ b/layouts/partials/google-analytics.html
@@ -1,4 +1,4 @@
-{{- if .Site.IsServer -}}
+{{- if hugo.IsServer -}}
   <!-- Dont add Google analytics to localhost -->
 {{ else }}
   {{ $gid := (getenv "HUGO_GOOGLE_ANALYTICS_ID") }}

--- a/layouts/services/single.html
+++ b/layouts/services/single.html
@@ -19,7 +19,7 @@
 {{ $library := resources.Get "js/libs/library.js" }}
 {{ $services := resources.Get "js/pages/services.js" }}
 {{ $servicesJS := slice $library $services |resources.Concat "js/services.js" }}
-{{ if .Site.IsServer }}
+{{ if hugo.IsServer }}
   <script type="text/javascript" src="{{ $servicesJS.RelPermalink }}"></script>
   {{ else }}
   <script type="text/javascript" src="{{ ($servicesJS | minify | fingerprint).RelPermalink }}"></script>

--- a/layouts/work/single.html
+++ b/layouts/work/single.html
@@ -31,7 +31,7 @@
 {{ $library := resources.Get "js/libs/library.js" }}
 {{ $services := resources.Get "js/pages/services.js" }}
 {{ $servicesJS := slice $library $services |resources.Concat "js/services.js" }}
-{{ if .Site.IsServer }}
+{{ if hugo.IsServer }}
   <script type="text/javascript" src="{{ $servicesJS.RelPermalink }}"></script>
   {{ else }}
   <script type="text/javascript" src="{{ ($servicesJS | minify | fingerprint).RelPermalink }}"></script>

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,6 @@
   command = "cd exampleSite && hugo --gc --themesDir ../.."
 
 [build.environment]
-  HUGO_VERSION = "0.95.0"
+  HUGO_VERSION = "0.133.0"
   HUGO_THEME = "repo"
   HUGO_BASEURL = "/"


### PR DESCRIPTION
`Site.IsServer` is deprecated since Hugo v0.120.0 and will be removed with Hugo v0.134.0.

With recent versions of Hugo (v0.133.0), building the theme will fail with the following error:
```
ERROR deprecated: .Site.IsServer was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.134.0. Use hugo.IsServer instead.
```

With this change, the use of `.Site.IsServer` is replaced with `hugo.IsServer`.

Also see:
[1] https://gohugo.io/methods/site/isserver/
[2] https://gohugo.io/functions/hugo/isserver/

Closes #72 